### PR TITLE
ci(matrix): quoted the `12.20` version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         node-version:
           # minimal required version
-          - 12.20
+          - '12.20'
           # minimal required version for latest semantic-release
           - 14.17
           # latest LTS version


### PR DESCRIPTION
since `12.2` is used without the quotes